### PR TITLE
fixing facebook url

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A curated list of data science blogs
 * Data Piques http://blog.ethanrosenthal.com/ [(RSS)](http://blog.ethanrosenthal.com/feeds/all.atom.xml)
 * Data School http://www.dataschool.io/ [(RSS)](http://www.dataschool.io/rss/)
 * Data Science 101 http://101.datascience.community/ [(RSS)](http://101.datascience.community/feed/)
-* Data Science @ Facebook https://research.facebook.com/blog/datascience/ [(RSS)](https://research.facebook.com/blog/datascience/)
+* Data Science @ Facebook https://research.fb.com/category/data-science/ [(RSS)](https://research.fb.com/category/data-science/feed/)
 * Data Science Insights http://www.datasciencebowl.com/data-science-insights/ [(RSS)](http://www.datasciencebowl.com/feed/)
 * Data Science Tutorials https://codementor.io/data-science/tutorial [(RSS)](https://www.codementor.io/data-science/tutorial/feed)
 * Data Science Vademecum http://datasciencevademecum.wordpress.com/ [(RSS)](http://datasciencevademecum.wordpress.com/feed/)

--- a/data-science.opml
+++ b/data-science.opml
@@ -62,7 +62,7 @@
 			<outline type="rss" text="Data Piques" title="Data Piques" xmlUrl="http://blog.ethanrosenthal.com/feeds/all.atom.xml" htmlUrl="http://blog.ethanrosenthal.com/"/>
 			<outline type="rss" text="Data School" title="Data School" xmlUrl="http://www.dataschool.io/rss/" htmlUrl="http://www.dataschool.io/"/>
 			<outline type="rss" text="Data Science 101" title="Data Science 101" xmlUrl="http://101.datascience.community/feed/" htmlUrl="http://101.datascience.community/"/>
-			<outline type="rss" text="Data Science @ Facebook" title="Data Science @ Facebook" xmlUrl="https://research.facebook.com/blog/datascience/" htmlUrl="https://research.facebook.com/blog/datascience/"/>
+			<outline type="rss" text="Data Science @ Facebook" title="Data Science @ Facebook" xmlUrl="https://research.fb.com/category/data-science/feed/" htmlUrl="https://research.fb.com/category/data-science/"/>
 			<outline type="rss" text="Data Science Insights" title="Data Science Insights" xmlUrl="http://www.datasciencebowl.com/feed/" htmlUrl="http://www.datasciencebowl.com/data-science-insights/"/>
 			<outline type="rss" text="Data Science Tutorials" title="Data Science Tutorials" xmlUrl="https://www.codementor.io/data-science/tutorial/feed" htmlUrl="https://codementor.io/data-science/tutorial"/>
 			<outline type="rss" text="Data Science Vademecum" title="Data Science Vademecum" xmlUrl="http://datasciencevademecum.wordpress.com/feed/" htmlUrl="http://datasciencevademecum.wordpress.com/"/>
@@ -248,4 +248,3 @@
         </outline>
     </body>
 </opml>
-    


### PR DESCRIPTION
The facebook data science blog link seems to have been updated to a different url. I have fixed it.