### PR TITLE
Add victorzhou.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ A curated list of data science blogs
 * Trevor Stephens http://trevorstephens.com/ [(RSS)](http://trevorstephens.com/feed.xml)
 * Trey Causey http://treycausey.com/ [(RSS)](http://treycausey.com/feeds/all.atom.xml)
 * UW Data Science Blog http://datasciencedegree.wisconsin.edu/blog/ [(RSS)](http://datasciencedegree.wisconsin.edu/feed/)
+* Victor Zhou https://victorzhou.com
 * Wellecks http://wellecks.wordpress.com/ [(RSS)](http://wellecks.wordpress.com/feed/)
 * Wes McKinney http://wesmckinney.com/archives.html [(RSS)](http://wesmckinney.com/feeds/all.atom.xml)
 * While My MCMC Gently Samples http://twiecki.github.io/ [(RSS)](http://twiecki.github.io/atom.xml)


### PR DESCRIPTION
Adds https://victorzhou.com to the list. It's still a relatively new blog, but there are already a few posts that have gotten significant traction:

- [An Introduction to Neural Networks](https://victorzhou.com/blog/intro-to-neural-networks/). Was the top post on [Hacker News](https://news.ycombinator.com/item?id=19320217) and was popular on [Reddit](https://www.reddit.com/r/Python/comments/axnvut/implementing_a_neural_network_from_scratch_in/?utm_source=share&utm_medium=web2x)
- [Better Profanity Detection with scikit-learn](https://victorzhou.com/blog/better-profanity-detection-with-scikit-learn/)

I'm the author of the blog and there will be significantly more machine learning posts to come.