### PR TITLE
Updated link after domain change neptune.ml -> neptune.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ A curated list of data science blogs
 * My thoughts on Data science, predictive analytics, Python http://shahramabyari.com/ [(RSS)](http://shahramabyari.com/feed/)
 * Natural language processing blog http://nlpers.blogspot.fr/ [(RSS)](http://nlpers.blogspot.com/feeds/posts/default)
 * Neil Lawrence http://inverseprobability.com/blog.html [(RSS)](http://inverseprobability.com/rss.xml)
-* Neptune's Blog: in-depth articles for machine learning practitioners https://neptune.ml/blog [(RSS)](https://neptune.ml/feed/)
+* Neptune Blog: in-depth articles for machine learning practitioners https://neptune.ai/blog [(RSS)](https://neptune.ml/feed/)
 * Nikolai Janakiev https://janakiev.com/ [(RSS)](https://janakiev.com/feed.xml)
 * NLP and Deep Learning enthusiast http://camron.xyz/ [(RSS)](http://camron.xyz/index.php/feed/)
 * no free hunch http://blog.kaggle.com/ [(RSS)](http://blog.kaggle.com/feed/)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ A curated list of data science blogs
 * My thoughts on Data science, predictive analytics, Python http://shahramabyari.com/ [(RSS)](http://shahramabyari.com/feed/)
 * Natural language processing blog http://nlpers.blogspot.fr/ [(RSS)](http://nlpers.blogspot.com/feeds/posts/default)
 * Neil Lawrence http://inverseprobability.com/blog.html [(RSS)](http://inverseprobability.com/rss.xml)
-* Neptune Blog: in-depth articles for machine learning practitioners https://neptune.ai/blog [(RSS)](https://neptune.ml/feed/)
+* Neptune Blog: in-depth articles for machine learning practitioners https://neptune.ai/blog [(RSS)](https://neptune.ai/feed/)
 * Nikolai Janakiev https://janakiev.com/ [(RSS)](https://janakiev.com/feed.xml)
 * NLP and Deep Learning enthusiast http://camron.xyz/ [(RSS)](http://camron.xyz/index.php/feed/)
 * no free hunch http://blog.kaggle.com/ [(RSS)](http://blog.kaggle.com/feed/)


### PR DESCRIPTION
We moved domain from neptune.ml -> neptune.ai and renamed the blog name from Neptune's blog to Neptune blog.